### PR TITLE
resources for the AWS EC2 image builder

### DIFF
--- a/config/prod/ec2-image-builder.yaml
+++ b/config/prod/ec2-image-builder.yaml
@@ -1,0 +1,4 @@
+template_path: "ec2-image-builder.yaml"
+stack_name: "ec2-image-builder"
+dependencies:
+  - "prod/service-linked-roles.yaml"

--- a/config/prod/service-linked-roles.yaml
+++ b/config/prod/service-linked-roles.yaml
@@ -1,4 +1,4 @@
-template_path: service-linked-roles.yaml
-stack_name: service-linked-roles
+template_path: "service-linked-roles.yaml"
+stack_name: "service-linked-roles"
 dependencies:
-  - prod/bootstrap.yaml
+  - "prod/bootstrap.yaml"

--- a/templates/ec2-image-builder.yaml
+++ b/templates/ec2-image-builder.yaml
@@ -1,0 +1,97 @@
+Description: Resources for the EC2 Image Builder
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'Platform'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'Infrastructure'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+    Default: 'it@sagebase.org'
+Resources:
+  ImageBuilderInstanceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+              - 'ec2.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - 'arn:aws:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+        - !Ref ImageBuilderLogsManagedolicy
+  ImageBuilderProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    Properties:
+      Path: "/"
+      Roles:
+        - !Ref ImageBuilderInstanceRole
+  # Bucket for EC2 image builder logs
+  ImageBuilderLogsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      AccessControl: PublicRead
+      Tags:
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  ImageBuilderLogsManagedolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetBucketLocation
+              - s3:ListAllMyBuckets
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource:
+              - !Sub "arn:aws:s3:::${ImageBuilderLogsBucket}"
+          - Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:DeleteObject
+            Resource:
+              - !Sub "arn:aws:s3:::${ImageBuilderLogsBucket}/*"
+Outputs:
+  ImageBuilderProfile:
+    Description: Profile to allow the image builder to provision instances
+    Value: !Ref ImageBuilderProfile
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageBuilderProfile'
+  ImageBuilderInstanceRole:
+    Description: Role to allow instances tag and receive management via Systems Manager
+    Value: !Ref ImageBuilderInstanceRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageBuilderInstanceRole'
+  ImageBuilderLogsBucket:
+    Description: Bucket containing EC2 Image builder logs
+    Value: !Ref ImageBuilderLogsBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageBuilderLogsBucket'

--- a/templates/service-linked-roles.yaml
+++ b/templates/service-linked-roles.yaml
@@ -5,6 +5,13 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Provision AWS service linked roles
 Resources:
+  # Role to grant EC2 Image Builder to manage building AMIs, only the Image Builder can assume this role.
+  # https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-service-linked-role.html
+  AWSServiceRoleForEc2ImageBuilder:
+    Type: "AWS::IAM::ServiceLinkedRole"
+    Properties:
+      AWSServiceName: "imagebuilder.amazonaws.com"
+      Description: "Allows EC2 Image Builder to call AWS services on your behalf."
   # Role to grant License Manager to manage licenses on EC2 image builder, only the License Manager can assume this roles.
   # https://docs.aws.amazon.com/license-manager/latest/userguide/using-service-linked-roles.html
   AWSServiceRoleForLicenseManager:
@@ -13,6 +20,10 @@ Resources:
       AWSServiceName: "license-manager.amazonaws.com"
       Description: "SLR for the AWS License Manager"
 Outputs:
+  AWSServiceRoleForEc2ImageBuilder:
+    Value: !Ref AWSServiceRoleForEc2ImageBuilder
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-AWSServiceRoleForEc2ImageBuilder'
   AWSServiceRoleForLicenseManager:
     Value: !Ref AWSServiceRoleForLicenseManager
     Export:


### PR DESCRIPTION
This sets up the AWS resources required to use the EC2 image builder.  The idea is to build AMIs in imagecentral account and share them with other sage accounts.