### PR TITLE
Restore a service account for packer builds

### DIFF
--- a/config/prod/service-accounts.yaml
+++ b/config/prod/service-accounts.yaml
@@ -1,0 +1,4 @@
+template_path: service-accounts.yaml
+stack_name: service-accounts
+dependencies:
+  - "prod/bootstrap.yaml"

--- a/templates/service-accounts.yaml
+++ b/templates/service-accounts.yaml
@@ -1,0 +1,49 @@
+Description: Setup service accounts
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  ImageLibrarianServiceUser:
+    Type: 'AWS::IAM::User'
+  ImageLibrarianServiceUserAccessKey:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref ImageLibrarianServiceUser
+  ImageLibrarianServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS:
+                - !GetAtt ImageLibrarianServiceUser.Arn
+            Action:
+              - "sts:AssumeRole"
+Outputs:
+  ImageLibrarianServiceUser:
+    Value: !Ref ImageLibrarianServiceUser
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageLibrarianServiceUser'
+  ImageLibrarianServiceUserArn:
+    Value: !GetAtt ImageLibrarianServiceUser.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageLibrarianServiceUserArn'
+  ImageLibrarianServiceUserAccessKey:
+    Value: !Ref ImageLibrarianServiceUserAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageLibrarianServiceUserAccessKey'
+  ImageLibrarianServiceUserSecretAccessKey:
+    Value: !GetAtt ImageLibrarianServiceUserAccessKey.SecretAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageLibrarianServiceUserSecretAccessKey'
+  ImageLibrarianServiceRole:
+    Value: !Ref ImageLibrarianServiceRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageLibrarianServiceRole'
+  ImageLibrarianServiceRoleArn:
+    Value: !GetAtt ImageLibrarianServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-ImageLibrarianServiceRoleArn'


### PR DESCRIPTION
We accidentally removed the packer service user in
PR https://github.com/Sage-Bionetworks/imagecentral-infra/pull/19
This PR restores that user and role.